### PR TITLE
Feat/handle update and delete logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       S3_OBJECT_KEY: test-object-key
       S3_ENDPOINT: http://mockserver:1080
       CONTEXT_MISSING_STRATEGY: LOG_ERROR
-    command: on-event.handler
+    command: handler.handler
     depends_on:
       - elasticsearch
 

--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -74,6 +74,89 @@ Feature: As a CloudFormation Stack
     """
 
   @clearElasticSearch
+  Scenario: OnEvent update index
+    Given lambda function "ON_EVENT_FUNCTION_NAME"
+    And AWS port "ON_EVENT_PORT"
+    And an elasticsearch index named "first-index" exists with mapping:
+    """
+    {
+      "mappings": {
+        "properties" : {
+          "field1" : { "type" : "text" }
+        }
+      }
+    }
+    """
+    And a index configuration file "ON_EVENT_S3_OBJECT_KEY" exists in bucket "ON_EVENT_S3_BUCKET_NAME" with contents:
+    """
+    {
+      "mappings": {
+        "properties" : {
+          "field1" : { "type" : "text" },
+          "field2" : { "type" : "text" }
+        }
+      }
+    }
+    """
+    When I send an event with body:
+    """
+    {
+      "RequestType": "Update"
+    }
+    """
+    Then an elasticsearch index prefixed with "ON_EVENT_INDEX" exists
+    And the elasticsearch index has mapping:
+    """
+    {
+      "properties" : {
+        "field1" : { "type" : "text" },
+        "field2" : { "type" : "text" }
+      }
+    }
+    """
+    And the response will match schema:
+    """
+    {
+      "definitions": {},
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "http://example.com/root.json",
+      "type": "object",
+      "title": "The Root Schema",
+      "required": [
+        "PhysicalResourceId",
+        "Data"
+      ],
+      "properties": {
+        "PhysicalResourceId": {
+          "$id": "#/properties/PhysicalResourceId",
+          "type": "string",
+          "examples": [
+            "somerandomstring"
+          ],
+          "pattern": "^[0-9a-fA-F]+$"
+        },
+        "Data": {
+          "$id": "#/properties/Data",
+          "type": "object",
+          "required": [
+            "IndexName"
+          ],
+          "properties": {
+            "IndexName": {
+              "$id": "#/properties/IndexName",
+              "type": "string",
+              "examples": [
+                "index-name-ABCDEFG"
+              ],
+              "pattern": "^.*-[a-f0-9]+$"
+            }
+          }
+        }
+      }
+    }
+    """
+
+  @clearElasticSearch
   Scenario: OnEvent delete index
     Given lambda function "ON_EVENT_FUNCTION_NAME"
     And AWS port "ON_EVENT_PORT"

--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -3,7 +3,7 @@ Feature: As a CloudFormation Stack
   In order to complete building a Stack
 
   @clearElasticSearch
-  Scenario: OnEvent
+  Scenario: OnEvent create index
     Given lambda function "ON_EVENT_FUNCTION_NAME"
     And AWS port "ON_EVENT_PORT"
     And a index configuration file "ON_EVENT_S3_OBJECT_KEY" exists in bucket "ON_EVENT_S3_BUCKET_NAME" with contents:
@@ -72,3 +72,28 @@ Feature: As a CloudFormation Stack
       }
     }
     """
+
+  @clearElasticSearch
+  Scenario: OnEvent delete index
+    Given lambda function "ON_EVENT_FUNCTION_NAME"
+    And AWS port "ON_EVENT_PORT"
+    And an elasticsearch index named "test-index" exists with mapping:
+    """
+    {
+      "mappings": {
+        "properties" : {
+          "field1" : { "type" : "text" }
+        }
+      }
+    }
+    """
+    When I send an event with body:
+    """
+    {
+      "RequestType": "Delete",
+      "ResourceProperties": {
+        "IndexName": "test-index"
+      }
+    }
+    """
+    Then an elasticsearch index prefixed with "ON_EVENT_INDEX" does not exist

--- a/features/step_definitions/elasticsearch_steps.ts
+++ b/features/step_definitions/elasticsearch_steps.ts
@@ -1,4 +1,4 @@
-import { Before, Then } from 'cucumber';
+import { Before, Given, Then } from 'cucumber';
 import { Client } from '@elastic/elasticsearch';
 import { expect } from 'chai';
 
@@ -26,6 +26,16 @@ Before({ tags: '@clearElasticSearch' }, async () => {
   }
 });
 
+Given(
+  /^an elasticsearch index named "([^"]*)" exists with mapping:$/,
+  async (indexNameEnv: string, mapping: string) => {
+    await getESClient().indices.create({
+      index: indexNameEnv,
+      body: mapping,
+    });
+  }
+);
+
 Then(
   /^an elasticsearch index prefixed with "([^"]*)" exists$/,
   async (indexNameEnv: string) => {
@@ -44,6 +54,15 @@ Then(
     }
     // tslint:disable-next-line:no-unused-expression
     expect(indexName).to.not.be.empty;
+  }
+);
+
+Then(
+  /^an elasticsearch index prefixed with "([^"]*)" does not exist$/,
+  async (indexNameEnv: string) => {
+    const indices = await getESClient().cat.indices();
+    // tslint:disable-next-line:no-unused-expression
+    expect(indices.body).to.not.contain(process.env[indexNameEnv]);
   }
 );
 

--- a/features/step_definitions/elasticsearch_steps.ts
+++ b/features/step_definitions/elasticsearch_steps.ts
@@ -28,9 +28,9 @@ Before({ tags: '@clearElasticSearch' }, async () => {
 
 Given(
   /^an elasticsearch index named "([^"]*)" exists with mapping:$/,
-  async (indexNameEnv: string, mapping: string) => {
+  async (existingIndexName: string, mapping: string) => {
     await getESClient().indices.create({
-      index: indexNameEnv,
+      index: existingIndexName,
       body: mapping,
     });
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,7 +38,7 @@ export class ElasticsearchIndex extends Construct {
     const onEventHandler = new Function(this, 'OnEventHandler', {
       runtime: Runtime.NODEJS_12_X,
       code: Code.fromAsset(onEventCodePath),
-      handler: 'on-event.handler',
+      handler: 'handler.handler',
       environment: {
         ELASTICSEARCH_ENDPOINT: props.elasticSearchEndpoint,
         ELASTICSEARCH_INDEX: props.elasticSearchIndex,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casechek/aws-cdk-elasticsearch-index",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.14",
   "description": "Elasticsearch Index Custom Resource for AWS CDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/src/on-event/handler.ts
+++ b/src/on-event/handler.ts
@@ -1,34 +1,25 @@
-import {
-  OnEventRequest,
-  OnEventResponse,
-} from '@aws-cdk/custom-resources/lib/provider-framework/types';
+import { OnEventHandler } from '@aws-cdk/custom-resources/lib/provider-framework/types';
 import { Client } from '@elastic/elasticsearch';
 import { S3 } from 'aws-sdk';
 import { createHandler } from './on-event';
 
 /* istanbul ignore next */
-export const handler = async (
-  event: OnEventRequest
-): Promise<OnEventResponse | undefined> => {
-  const s3 = new S3({
-    endpoint: process.env.S3_ENDPOINT,
-    s3ForcePathStyle: true,
-  });
-  const es = new Client({ node: process.env.ELASTICSEARCH_ENDPOINT });
-  const response = await createHandler(
-    s3,
-    es,
-    {
-      Bucket: process.env.S3_BUCKET_NAME as string,
-      Key: process.env.S3_OBJECT_KEY as string,
-    },
-    process.env.ELASTICSEARCH_INDEX as string,
-    console,
-    process.env.MAX_HEALTH_RETRIES
-      ? Number(process.env.MAX_HEALTH_RETRIES)
-      : undefined
-  )(event);
+const s3 = new S3({
+  endpoint: process.env.S3_ENDPOINT,
+  s3ForcePathStyle: true,
+});
+const es = new Client({ node: process.env.ELASTICSEARCH_ENDPOINT });
 
-  console.log('response', response);
-  return response;
-};
+export const handler: OnEventHandler = createHandler(
+  s3,
+  es,
+  {
+    Bucket: process.env.S3_BUCKET_NAME as string,
+    Key: process.env.S3_OBJECT_KEY as string,
+  },
+  process.env.ELASTICSEARCH_INDEX as string,
+  console,
+  process.env.MAX_HEALTH_RETRIES
+    ? Number(process.env.MAX_HEALTH_RETRIES)
+    : undefined
+);

--- a/src/on-event/handler.ts
+++ b/src/on-event/handler.ts
@@ -1,0 +1,34 @@
+import {
+  OnEventRequest,
+  OnEventResponse,
+} from '@aws-cdk/custom-resources/lib/provider-framework/types';
+import { Client } from '@elastic/elasticsearch';
+import { S3 } from 'aws-sdk';
+import { createHandler } from './on-event';
+
+/* istanbul ignore next */
+export const handler = async (
+  event: OnEventRequest
+): Promise<OnEventResponse | undefined> => {
+  const s3 = new S3({
+    endpoint: process.env.S3_ENDPOINT,
+    s3ForcePathStyle: true,
+  });
+  const es = new Client({ node: process.env.ELASTICSEARCH_ENDPOINT });
+  const response = await createHandler(
+    s3,
+    es,
+    {
+      Bucket: process.env.S3_BUCKET_NAME as string,
+      Key: process.env.S3_OBJECT_KEY as string,
+    },
+    process.env.ELASTICSEARCH_INDEX as string,
+    console,
+    process.env.MAX_HEALTH_RETRIES
+      ? Number(process.env.MAX_HEALTH_RETRIES)
+      : undefined
+  )(event);
+
+  console.log('response', response);
+  return response;
+};

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -51,7 +51,6 @@ export const createHandler = (
   es: Client,
   bucketParams: S3.GetObjectRequest,
   indexNamePrefix: string,
-  // tslint:disable-next-line:no-any
   logger: { log: (...value: unknown[]) => void } = { log: () => {} },
   maxHealthRetries?: number
 ): OnEventHandler => {

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -10,6 +10,41 @@ import { INDEX_NAME_KEY } from './constants';
 
 export class TimeoutError extends Error {}
 
+const getMappingFromBucket = async (
+  s3: S3,
+  bucketParams: S3.GetObjectRequest
+): Promise<string> => {
+  const s3ObjectResponse = await s3.getObject(bucketParams).promise();
+  return JSON.parse((s3ObjectResponse.Body as Buffer).toString());
+};
+
+const checkClusterHealth = async (
+  es: Client,
+  maxRetries = 10,
+  // tslint:disable-next-line:no-any
+  logger: (...value: any) => void
+) => {
+  let retryHealth = maxRetries;
+  while (retryHealth > 0) {
+    const response = await es.cluster.health(
+      {
+        wait_for_status: 'yellow',
+        timeout: '60s',
+      },
+      { maxRetries: 0 }
+    );
+    logger('received health response', response.body);
+    if (response.body.timed_out) {
+      retryHealth -= 1;
+      if (retryHealth === 0) {
+        throw new TimeoutError();
+      }
+    } else {
+      retryHealth = 0;
+    }
+  }
+};
+
 export function createHandler(params: {
   s3: S3;
   es: Client;
@@ -25,41 +60,17 @@ export function createHandler(params: {
     const log = params.logger?.log ?? mockLog; // two lines because PhpStorm doesn't quite handle ?? correctly in the case of a function as value
 
     if (event.RequestType === 'Create') {
-      log(event);
-      const s3ObjectResponse = await params.s3
-        .getObject({
-          Bucket: params.bucketName,
-          Key: params.objectKey,
-        })
-        .promise();
-
-      const mapping = JSON.parse((s3ObjectResponse.Body as Buffer).toString());
-      log('downloaded s3 object', mapping);
-
-      log('waiting for cluster to become healthy');
-      let retryHealth = params.maxHealthRetries ?? 10;
-      while (retryHealth > 0) {
-        const response = await params.es.cluster.health(
-          {
-            wait_for_status: 'yellow',
-            timeout: '60s',
-          },
-          { maxRetries: 0 }
-        );
-        log('received health response', response.body);
-        if (response.body.timed_out) {
-          retryHealth -= 1;
-          if (retryHealth === 0) {
-            throw new TimeoutError();
-          }
-        } else {
-          retryHealth = 0;
-        }
-      }
+      const mapping = await getMappingFromBucket(params.s3, {
+        Bucket: params.bucketName,
+        Key: params.objectKey,
+      });
+      log('Downloaded mapping from S3:', mapping);
+      log('Waiting for cluster to become healthy');
+      await checkClusterHealth(params.es, params.maxHealthRetries, log);
 
       const indexId = randomBytes(16).toString('hex');
       const indexName = `${params.indexNamePrefix}-${indexId}`;
-      log(`attempting to create index ${indexName}`);
+      log(`Attempting to create index ${indexName}`);
       const response = await params.es.indices.create(
         {
           index: indexName,
@@ -68,7 +79,7 @@ export function createHandler(params: {
         { requestTimeout: 120 * 1000, maxRetries: 0 }
       );
 
-      log('response from create index', response);
+      log('Response from create index:', response);
       return {
         PhysicalResourceId: indexId,
         Data: {

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -100,34 +100,6 @@ export const createHandler = (
         throw new Error();
       }
     }
-
     return {};
   };
-};
-
-/* istanbul ignore next */
-export const handler = async (
-  event: OnEventRequest
-): Promise<OnEventResponse | undefined> => {
-  const s3 = new S3({
-    endpoint: process.env.S3_ENDPOINT,
-    s3ForcePathStyle: true,
-  });
-  const es = new Client({ node: process.env.ELASTICSEARCH_ENDPOINT });
-  const response = await createHandler(
-    s3,
-    es,
-    {
-      Bucket: process.env.S3_BUCKET_NAME as string,
-      Key: process.env.S3_OBJECT_KEY as string,
-    },
-    process.env.ELASTICSEARCH_INDEX as string,
-    console,
-    process.env.MAX_HEALTH_RETRIES
-      ? Number(process.env.MAX_HEALTH_RETRIES)
-      : undefined
-  )(event);
-
-  console.log('response', response);
-  return response;
 };

--- a/test/lib/elasticsearch-index.spec.ts
+++ b/test/lib/elasticsearch-index.spec.ts
@@ -27,7 +27,7 @@ describe('Elasticsearch Index Custom Resource Stack', () => {
 
     // THEN
     expectCDK(stack).to(
-      haveResource('AWS::Lambda::Function', { Handler: 'on-event.handler' })
+      haveResource('AWS::Lambda::Function', { Handler: 'handler.handler' })
     );
   });
 });

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -1,5 +1,8 @@
 import { createHandler, TimeoutError } from '../../../src/on-event/on-event';
-import { OnEventRequest } from '@aws-cdk/custom-resources/lib/provider-framework/types';
+import {
+  OnEventRequest,
+  OnEventHandler,
+} from '@aws-cdk/custom-resources/lib/provider-framework/types';
 import { S3 } from 'aws-sdk';
 import { Client } from '@elastic/elasticsearch';
 import { INDEX_NAME_KEY } from '../../../src/on-event/constants';
@@ -16,6 +19,7 @@ jest.mock('crypto', () => ({
 describe('OnEvent Handler', () => {
   let s3: S3;
   let es: Client;
+  let handler: OnEventHandler;
 
   beforeEach(() => {
     s3 = new S3();
@@ -23,6 +27,15 @@ describe('OnEvent Handler', () => {
       promise: jest.fn().mockResolvedValue({ Body: Buffer.from('{}') }),
     });
     es = new Client();
+    handler = createHandler({
+      s3,
+      es,
+      bucketParams: {
+        Bucket: 'bucket',
+        Key: 'key',
+      },
+      indexNamePrefix: 'index',
+    });
   });
 
   it('creates index on create event', async () => {
@@ -50,16 +63,6 @@ describe('OnEvent Handler', () => {
         .mockResolvedValue(true),
       // tslint:disable-next-line:no-any
     } as any;
-
-    const handler = createHandler({
-      s3,
-      es,
-      bucketParams: {
-        Bucket: 'bucket',
-        Key: 'key',
-      },
-      indexNamePrefix: 'index',
-    });
 
     cryptoToStringFn.mockReturnValue('random');
 
@@ -92,7 +95,7 @@ describe('OnEvent Handler', () => {
       // tslint:disable-next-line:no-any
     } as any;
 
-    const handler = createHandler({
+    handler = createHandler({
       s3,
       es,
       bucketParams: {
@@ -132,16 +135,6 @@ describe('OnEvent Handler', () => {
       // tslint:disable-next-line:no-any
     } as any;
 
-    const handler = createHandler({
-      s3,
-      es,
-      bucketParams: {
-        Bucket: 'bucket',
-        Key: 'key',
-      },
-      indexNamePrefix: 'index',
-    });
-
     // WHEN
     const result = await handler({
       RequestType: 'Create',
@@ -159,16 +152,6 @@ describe('OnEvent Handler', () => {
         .mockResolvedValue({ statusCode: 200 }),
       // tslint:disable-next-line:no-any
     } as any;
-
-    const handler = createHandler({
-      s3,
-      es,
-      bucketParams: {
-        Bucket: 'bucket',
-        Key: 'key',
-      },
-      indexNamePrefix: 'index',
-    });
 
     // WHEN
     const result = await handler(({
@@ -195,16 +178,6 @@ describe('OnEvent Handler', () => {
         .mockResolvedValue({ statusCode: 404 }),
       // tslint:disable-next-line:no-any
     } as any;
-
-    const handler = createHandler({
-      s3,
-      es,
-      bucketParams: {
-        Bucket: 'bucket',
-        Key: 'key',
-      },
-      indexNamePrefix: 'index',
-    });
 
     // WHEN
     await expect(

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -27,15 +27,15 @@ describe('OnEvent Handler', () => {
       promise: jest.fn().mockResolvedValue({ Body: Buffer.from('{}') }),
     });
     es = new Client();
-    handler = createHandler({
+    handler = createHandler(
       s3,
       es,
-      bucketParams: {
+      {
         Bucket: 'bucket',
         Key: 'key',
       },
-      indexNamePrefix: 'index',
-    });
+      'index'
+    );
   });
 
   it('creates index on create event', async () => {
@@ -95,16 +95,17 @@ describe('OnEvent Handler', () => {
       // tslint:disable-next-line:no-any
     } as any;
 
-    handler = createHandler({
+    handler = createHandler(
       s3,
       es,
-      bucketParams: {
+      {
         Bucket: 'bucket',
         Key: 'key',
       },
-      indexNamePrefix: 'index',
-      maxHealthRetries: 2,
-    });
+      'index',
+      { log: () => {} },
+      2
+    );
 
     await expect(
       handler({

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -45,11 +45,6 @@ describe('OnEvent Handler', () => {
         .mockImplementation()
         .mockResolvedValueOnce({
           body: {
-            timed_out: true,
-          },
-        })
-        .mockResolvedValueOnce({
-          body: {
             timed_out: false,
           },
         }),
@@ -94,18 +89,6 @@ describe('OnEvent Handler', () => {
         }),
       // tslint:disable-next-line:no-any
     } as any;
-
-    handler = createHandler(
-      s3,
-      es,
-      {
-        Bucket: 'bucket',
-        Key: 'key',
-      },
-      'index',
-      { log: () => {} },
-      2
-    );
 
     await expect(
       handler({

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -54,8 +54,10 @@ describe('OnEvent Handler', () => {
     const handler = createHandler({
       s3,
       es,
-      bucketName: 'bucket',
-      objectKey: 'key',
+      bucketParams: {
+        Bucket: 'bucket',
+        Key: 'key',
+      },
       indexNamePrefix: 'index',
     });
 
@@ -93,8 +95,10 @@ describe('OnEvent Handler', () => {
     const handler = createHandler({
       s3,
       es,
-      bucketName: 'bucket',
-      objectKey: 'key',
+      bucketParams: {
+        Bucket: 'bucket',
+        Key: 'key',
+      },
       indexNamePrefix: 'index',
       maxHealthRetries: 2,
     });
@@ -131,8 +135,10 @@ describe('OnEvent Handler', () => {
     const handler = createHandler({
       s3,
       es,
-      bucketName: 'bucket',
-      objectKey: 'key',
+      bucketParams: {
+        Bucket: 'bucket',
+        Key: 'key',
+      },
       indexNamePrefix: 'index',
     });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = (env, argv) => {
     target: 'node',
     devtool: 'eval-source-map',
     entry: {
-      'on-event': './src/on-event/on-event.ts',
+      'handler': './src/on-event/handler.ts',
     },
     module: {
       rules: [
@@ -35,7 +35,7 @@ module.exports = (env, argv) => {
     },
     externals: ['aws-sdk'],
     output: {
-      filename: '[name]/[name].js',
+      filename: 'on-event/[name].js',
       path: path.resolve(__dirname, 'dist', 'resources'),
       libraryTarget: 'commonjs',
     },


### PR DESCRIPTION
# Responding Update and Delete events

This PR aims to bring support for Update and Delete Cloudformation requests when the construct gets updated or deleted.

Basically, when the stack receives an Update event, it will do the same thing as a Create event and create a new index. OnEvent will however return a different physical resource id (since that values comes from the randomly generated hash). 
This WILL trigger a delete event for the older construct, as the documentation indicates: https://docs.aws.amazon.com/cdk/api/latest/docs/custom-resources-readme.html.
![image](https://user-images.githubusercontent.com/33158766/81730339-fbbe4000-9452-11ea-8e23-35c86fcb449c.png)

Also updated unit tests and E2E tests. Though that last functionality (the automatic deletes) isn't tested since that's detected by cloudformation.