### PR TITLE
fix: cdk update trigger

### DIFF
--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -48,7 +48,7 @@ Feature: As a CloudFormation Stack
           "$id": "#/properties/PhysicalResourceId",
           "type": "string",
           "examples": [
-            "somerandomstring"
+            "somerandomestring-0123abc"
           ],
           "pattern": "^.*-[a-f0-9]+$"
         },
@@ -144,7 +144,7 @@ Feature: As a CloudFormation Stack
           "$id": "#/properties/PhysicalResourceId",
           "type": "string",
           "examples": [
-            "somerandomstring"
+            "somerandomestring-0123abc"
           ],
           "pattern": "^.*-[a-f0-9]+$"
         },

--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -101,7 +101,8 @@ Feature: As a CloudFormation Stack
     When I send an event with body:
     """
     {
-      "RequestType": "Update"
+      "RequestType": "Update",
+      "PhysicalResourceId": "first-index"
     }
     """
     Then an elasticsearch index prefixed with "ON_EVENT_INDEX" exists

--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -50,7 +50,7 @@ Feature: As a CloudFormation Stack
           "examples": [
             "somerandomstring"
           ],
-          "pattern": "^[0-9a-fA-F]+$"
+          "pattern": "^.*-[a-f0-9]+$"
         },
         "Data": {
           "$id": "#/properties/Data",
@@ -133,7 +133,7 @@ Feature: As a CloudFormation Stack
           "examples": [
             "somerandomstring"
           ],
-          "pattern": "^[0-9a-fA-F]+$"
+          "pattern": "^.*-[a-f0-9]+$"
         },
         "Data": {
           "$id": "#/properties/Data",
@@ -174,9 +174,7 @@ Feature: As a CloudFormation Stack
     """
     {
       "RequestType": "Delete",
-      "ResourceProperties": {
-        "IndexName": "test-index"
-      }
+      "PhysicalResourceId": 'test-index'
     }
     """
     Then an elasticsearch index prefixed with "ON_EVENT_INDEX" does not exist

--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -87,6 +87,12 @@ Feature: As a CloudFormation Stack
       }
     }
     """
+    And an elasticsearch index named "first-index" has this document indexed:
+    """
+    {
+      "field1": "le-foo-value"
+    }
+    """
     And a index configuration file "ON_EVENT_S3_OBJECT_KEY" exists in bucket "ON_EVENT_S3_BUCKET_NAME" with contents:
     """
     {
@@ -113,6 +119,12 @@ Feature: As a CloudFormation Stack
         "field1" : { "type" : "text" },
         "field2" : { "type" : "text" }
       }
+    }
+    """
+    And the elasticsearch index has this document indexed:
+    """
+    {
+      "field1": "le-foo-value"
     }
     """
     And the response will match schema:

--- a/features/on_event.feature
+++ b/features/on_event.feature
@@ -174,7 +174,7 @@ Feature: As a CloudFormation Stack
     """
     {
       "RequestType": "Delete",
-      "PhysicalResourceId": 'test-index'
+      "PhysicalResourceId": "test-index"
     }
     """
     Then an elasticsearch index prefixed with "ON_EVENT_INDEX" does not exist

--- a/features/step_definitions/elasticsearch_steps.ts
+++ b/features/step_definitions/elasticsearch_steps.ts
@@ -41,6 +41,7 @@ Then(
   async (indexNameEnv: string) => {
     const indices = await getESClient().cat.indices();
 
+    console.log(indices.body);
     // tslint:disable-next-line:no-unused-expression
     expect(indices.body).to.contain(process.env[indexNameEnv]);
     expect(indices.statusCode).to.be.equal(200);

--- a/features/step_definitions/elasticsearch_steps.ts
+++ b/features/step_definitions/elasticsearch_steps.ts
@@ -36,6 +36,17 @@ Given(
   }
 );
 
+Given(
+  /^an elasticsearch index named "([^"]*)" has this document indexed:$/,
+  async (existingIndexName: string, mapping: string) => {
+    await getESClient().index({
+      index: existingIndexName,
+      refresh: 'true',
+      body: mapping,
+    });
+  }
+);
+
 Then(
   /^an elasticsearch index prefixed with "([^"]*)" exists$/,
   async (indexNameEnv: string) => {
@@ -74,3 +85,15 @@ Then(/^the elasticsearch index has mapping:$/, async (expected: string) => {
 
   expect(mapping.body[indexName].mappings).to.deep.equal(JSON.parse(expected));
 });
+
+Then(
+  /^the elasticsearch index has this document indexed:$/,
+  async (expected: string) => {
+    const result = await getESClient().search({
+      index: indexName as string,
+      body: { query: { match: JSON.parse(expected) } },
+    });
+
+    expect(result.body.hits.total.value).to.deep.equal(1);
+  }
+);

--- a/features/step_definitions/elasticsearch_steps.ts
+++ b/features/step_definitions/elasticsearch_steps.ts
@@ -52,7 +52,6 @@ Then(
   async (indexNameEnv: string) => {
     const indices = await getESClient().cat.indices();
 
-    console.log(indices.body);
     // tslint:disable-next-line:no-unused-expression
     expect(indices.body).to.contain(process.env[indexNameEnv]);
     expect(indices.statusCode).to.be.equal(200);
@@ -94,6 +93,6 @@ Then(
       body: { query: { match: JSON.parse(expected) } },
     });
 
-    expect(result.body.hits.total.value).to.deep.equal(1);
+    expect(result.body.hits.total.value).to.equal(1);
   }
 );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,8 +68,8 @@ export class ElasticsearchIndex extends Construct {
     const resource = new CustomResource(this, 'ElasticsearchIndex', {
       serviceToken: provider.serviceToken,
       properties: {
-        mappingJSONPath: props.mappingJSONPath
-      }
+        mappingJSONPath: props.mappingJSONPath,
+      },
     });
 
     this.indexName = resource.getAttString(INDEX_NAME_KEY);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,6 +67,9 @@ export class ElasticsearchIndex extends Construct {
 
     const resource = new CustomResource(this, 'ElasticsearchIndex', {
       serviceToken: provider.serviceToken,
+      properties: {
+        mappingJSONPath: props.mappingJSONPath
+      }
     });
 
     this.indexName = resource.getAttString(INDEX_NAME_KEY);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casechek/aws-cdk-elasticsearch-index",
-  "version": "1.0.0-alpha.14",
+  "version": "1.0.0-alpha.16",
   "description": "Elasticsearch Index Custom Resource for AWS CDK",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -56,6 +56,7 @@ export const createHandler = (
 ): OnEventHandler => {
   return async (event: OnEventRequest): Promise<OnEventResponse> => {
     const log = logger.log;
+    log('Received event:', event);
     if (['Create', 'Update'].includes(event.RequestType)) {
       const mapping = await getMappingFromBucket(s3, bucketParams);
       log('Downloaded mapping from S3:', mapping);

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -130,6 +130,6 @@ export const createHandler = (
       return { PhysicalResourceId: currentIndexName };
     }
 
-    return {};
+    throw new Error('Unknown Request Type');
   };
 };

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -58,9 +58,6 @@ const reIndexAllDocuments = async (
       },
     },
   });
-  if (response.body.timed_out) {
-    throw new TimeoutError();
-  }
 };
 
 export const createHandler = (
@@ -103,7 +100,7 @@ export const createHandler = (
         mapping
       );
       log(`Created index ${newIndexName}`);
-      await reIndexAllDocuments(es, oldIndexName, newIndexName);
+      // await reIndexAllDocuments(es, oldIndexName, newIndexName);
       return {
         PhysicalResourceId: newIndexName,
         Data: { [INDEX_NAME_KEY]: newIndexName },

--- a/src/on-event/on-event.ts
+++ b/src/on-event/on-event.ts
@@ -47,8 +47,10 @@ const reIndexAllDocuments = async (
   oldIndex: string,
   newIndex: string
 ) => {
+  console.log(`The indices are new: ${oldIndex} and old: ${newIndex}`);
   const response = await es.reindex({
     wait_for_completion: true,
+    refresh: true,
     body: {
       source: {
         index: oldIndex,
@@ -58,6 +60,9 @@ const reIndexAllDocuments = async (
       },
     },
   });
+  if (response.body.timed_out) {
+    throw new TimeoutError();
+  }
 };
 
 export const createHandler = (
@@ -100,7 +105,7 @@ export const createHandler = (
         mapping
       );
       log(`Created index ${newIndexName}`);
-      // await reIndexAllDocuments(es, oldIndexName, newIndexName);
+      await reIndexAllDocuments(es, oldIndexName, newIndexName);
       return {
         PhysicalResourceId: newIndexName,
         Data: { [INDEX_NAME_KEY]: newIndexName },

--- a/test/lib/elasticsearch-index.spec.ts
+++ b/test/lib/elasticsearch-index.spec.ts
@@ -1,10 +1,7 @@
 import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 import * as path from 'path';
-import { exec } from 'child_process';
-import { existsSync } from 'fs';
 import { ElasticsearchIndex } from '../../lib';
-import { promisify } from 'util';
 
 describe('Elasticsearch Index Custom Resource Stack', () => {
   it('Creates On Event Handler', async () => {

--- a/test/lib/elasticsearch-index.spec.ts
+++ b/test/lib/elasticsearch-index.spec.ts
@@ -21,6 +21,7 @@ describe('Elasticsearch Index Custom Resource Stack', () => {
         mappingJSONPath: path.join(__dirname, 'resources', 'mapping.json'),
         elasticSearchEndpoint: 'domain',
         elasticSearchIndex: 'index',
+        policyArn: 'arn::some-arn',
       },
       __dirname
     );

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -192,7 +192,7 @@ describe('OnEvent Handler', () => {
       handler(({
         RequestType: 'Update',
       } as unknown) as OnEventRequest)
-    ).rejects.toThrow(Error);
+    ).rejects.toThrowError('event.PhysicalResourceId is required');
   });
 
   it('deletes index on delete event', async () => {
@@ -235,6 +235,6 @@ describe('OnEvent Handler', () => {
       handler(({
         RequestType: 'Delete',
       } as unknown) as OnEventRequest)
-    ).rejects.toThrow(Error);
+    ).rejects.toThrowError('event.PhysicalResourceId is required');
   });
 });

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -237,4 +237,13 @@ describe('OnEvent Handler', () => {
       } as unknown) as OnEventRequest)
     ).rejects.toThrowError('event.PhysicalResourceId is required');
   });
+
+  it('throws when a request is not an expected type', async () => {
+    // WHEN and THEN
+    await expect(
+      handler(({
+        RequestType: 'Other',
+      } as unknown) as OnEventRequest)
+    ).rejects.toThrowError('Unknown Request Type');
+  });
 });

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -36,17 +36,6 @@ jest.mock('@elastic/elasticsearch', () => ({
 }));
 import { createHandler, TimeoutError } from '../../../src/on-event/on-event';
 
-const noTimeOutResponse = {
-  body: {
-    timed_out: false,
-  },
-};
-
-const timeOutResponse = {
-  body: {
-    timed_out: true,
-  },
-};
 describe('OnEvent Handler', () => {
   let handler: OnEventHandler;
 
@@ -73,7 +62,11 @@ describe('OnEvent Handler', () => {
   });
 
   it('creates index on create event', async () => {
-    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
+    mockEsHealth.mockResolvedValueOnce({
+      body: {
+        timed_out: false,
+      },
+    });
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
 
@@ -94,7 +87,11 @@ describe('OnEvent Handler', () => {
   });
 
   it('throws if never healthy', async () => {
-    mockEsHealth.mockResolvedValueOnce(timeOutResponse);
+    mockEsHealth.mockResolvedValueOnce({
+      body: {
+        timed_out: true,
+      },
+    });
 
     await expect(
       handler({
@@ -105,7 +102,11 @@ describe('OnEvent Handler', () => {
 
   it('returns index name on create', async () => {
     // GIVEN
-    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
+    mockEsHealth.mockResolvedValueOnce({
+      body: {
+        timed_out: false,
+      },
+    });
     mockEsCreate.mockResolvedValueOnce(true);
 
     // WHEN
@@ -118,8 +119,16 @@ describe('OnEvent Handler', () => {
   });
 
   it('updates index on update event', async () => {
-    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
-    mockEsReIndex.mockResolvedValueOnce(noTimeOutResponse);
+    mockEsHealth.mockResolvedValueOnce({
+      body: {
+        timed_out: false,
+      },
+    });
+    mockEsReIndex.mockResolvedValueOnce({
+      body: {
+        timed_out: false,
+      },
+    });
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
 
@@ -156,8 +165,16 @@ describe('OnEvent Handler', () => {
   });
 
   it('throws if reindex request times out', async () => {
-    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
-    mockEsReIndex.mockResolvedValueOnce(timeOutResponse);
+    mockEsHealth.mockResolvedValueOnce({
+      body: {
+        timed_out: false,
+      },
+    });
+    mockEsReIndex.mockResolvedValueOnce({
+      body: {
+        timed_out: true,
+      },
+    });
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
 

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -122,16 +122,12 @@ describe('OnEvent Handler', () => {
     // WHEN
     const result = await handler(({
       RequestType: 'Delete',
-      ResourceProperties: {
-        IndexName: 'existing-index',
-      },
+      PhysicalResourceId: 'existing-index',
     } as unknown) as OnEventRequest);
 
     // THEN
     expect(mockEsDelete).toHaveBeenCalledWith(
-      {
-        index: 'existing-index',
-      },
+      { index: 'existing-index' },
       { requestTimeout: 120 * 1000, maxRetries: 0 }
     );
   });
@@ -143,17 +139,13 @@ describe('OnEvent Handler', () => {
     await expect(
       handler(({
         RequestType: 'Delete',
-        ResourceProperties: {
-          IndexName: 'existing-index',
-        },
+        PhysicalResourceId: 'existing-index',
       } as unknown) as OnEventRequest)
     ).rejects.toThrow(Error);
 
     // THEN
     expect(mockEsDelete).toHaveBeenCalledWith(
-      {
-        index: 'existing-index',
-      },
+      { index: 'existing-index' },
       { requestTimeout: 120 * 1000, maxRetries: 0 }
     );
   });

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -36,6 +36,17 @@ jest.mock('@elastic/elasticsearch', () => ({
 }));
 import { createHandler, TimeoutError } from '../../../src/on-event/on-event';
 
+const noTimeOutResponse = {
+  body: {
+    timed_out: false,
+  },
+};
+
+const timeOutResponse = {
+  body: {
+    timed_out: true,
+  },
+};
 describe('OnEvent Handler', () => {
   let handler: OnEventHandler;
 
@@ -62,11 +73,7 @@ describe('OnEvent Handler', () => {
   });
 
   it('creates index on create event', async () => {
-    mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
-    });
+    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
 
@@ -87,11 +94,7 @@ describe('OnEvent Handler', () => {
   });
 
   it('throws if never healthy', async () => {
-    mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: true,
-      },
-    });
+    mockEsHealth.mockResolvedValueOnce(timeOutResponse);
 
     await expect(
       handler({
@@ -102,11 +105,7 @@ describe('OnEvent Handler', () => {
 
   it('returns index name on create', async () => {
     // GIVEN
-    mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
-    });
+    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
     mockEsCreate.mockResolvedValueOnce(true);
 
     // WHEN
@@ -119,16 +118,8 @@ describe('OnEvent Handler', () => {
   });
 
   it('updates index on update event', async () => {
-    mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
-    });
-    mockEsReIndex.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
-    });
+    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
+    mockEsReIndex.mockResolvedValueOnce(noTimeOutResponse);
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
 
@@ -165,16 +156,8 @@ describe('OnEvent Handler', () => {
   });
 
   it('throws if reindex request times out', async () => {
-    mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
-    });
-    mockEsReIndex.mockResolvedValueOnce({
-      body: {
-        timed_out: true,
-      },
-    });
+    mockEsHealth.mockResolvedValueOnce(noTimeOutResponse);
+    mockEsReIndex.mockResolvedValueOnce(timeOutResponse);
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
 

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -206,7 +206,7 @@ describe('OnEvent Handler', () => {
         RequestType: 'Delete',
         PhysicalResourceId: 'existing-index',
       } as unknown) as OnEventRequest)
-    ).rejects.toThrow(Error);
+    ).rejects.toThrowError('Error when deleting the older index.');
 
     // THEN
     expect(mockEsDelete).toHaveBeenCalledWith(

--- a/test/src/on-event/on-event.spec.ts
+++ b/test/src/on-event/on-event.spec.ts
@@ -63,9 +63,7 @@ describe('OnEvent Handler', () => {
 
   it('creates index on create event', async () => {
     mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
+      body: { timed_out: false },
     });
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
@@ -88,9 +86,7 @@ describe('OnEvent Handler', () => {
 
   it('throws if never healthy', async () => {
     mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: true,
-      },
+      body: { timed_out: true },
     });
 
     await expect(
@@ -103,9 +99,7 @@ describe('OnEvent Handler', () => {
   it('returns index name on create', async () => {
     // GIVEN
     mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
+      body: { timed_out: false },
     });
     mockEsCreate.mockResolvedValueOnce(true);
 
@@ -120,14 +114,10 @@ describe('OnEvent Handler', () => {
 
   it('updates index on update event', async () => {
     mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
+      body: { timed_out: false },
     });
     mockEsReIndex.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
+      body: { timed_out: false },
     });
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');
@@ -166,14 +156,10 @@ describe('OnEvent Handler', () => {
 
   it('throws if reindex request times out', async () => {
     mockEsHealth.mockResolvedValueOnce({
-      body: {
-        timed_out: false,
-      },
+      body: { timed_out: false },
     });
     mockEsReIndex.mockResolvedValueOnce({
-      body: {
-        timed_out: true,
-      },
+      body: { timed_out: true },
     });
     mockEsCreate.mockResolvedValueOnce(true);
     cryptoToStringFn.mockReturnValue('random');


### PR DESCRIPTION
We have QAed that this work on the `bob-318` stack. If there is any change to the mapping, then a new index is created and the older one gets deleted.

The indexed documents are not re-indexed though, but that's out of scope for now.

**Edit**: ended up adding that reindexing-docs-during-the-update feature, tested and everything it's super swell